### PR TITLE
Fix mark seen with volume hardware browsing

### DIFF
--- a/org.fox.ttrss/src/main/java/org/fox/ttrss/HeadlinesFragment.java
+++ b/org.fox.ttrss/src/main/java/org/fox/ttrss/HeadlinesFragment.java
@@ -1639,14 +1639,16 @@ public class HeadlinesFragment extends androidx.fragment.app.Fragment {
 
     /**
      * Scrolls the headlines list down by one page height
-     * @return true if scrolling was performed, false if already at bottom
+     * @return true if scrolling was performed or refresh triggered
      */
     public boolean scrollDown() {
         if (m_list == null) return false;
 
         // Check if we can scroll down
         if (!m_list.canScrollVertically(1)) {
-            return false; // Already at bottom
+            // Already at bottom, trigger refresh instead
+            m_activity.refresh(false);
+            return true;
         }
 
         // Scroll down by one page (use view height as page size)


### PR DESCRIPTION
When automatic mark as seen option is selected, honor it with hardware volume based browsing in headlines.
Also at the end of the list volume - causes refresh.

I know the project is EOL but wanted to add this to previous PR for correct behavior.