### PR TITLE
Fix NullPointerException in HeadlinesFragment Snackbar

### DIFF
--- a/org.fox.ttrss/src/main/java/org/fox/ttrss/HeadlinesFragment.java
+++ b/org.fox.ttrss/src/main/java/org/fox/ttrss/HeadlinesFragment.java
@@ -484,7 +484,7 @@ public class HeadlinesFragment extends androidx.fragment.app.Fragment {
                     m_listener.onHeadlinesLoaded(appended);
                 });
 
-                if (model.getFirstIdChanged())
+                if (model.getFirstIdChanged() && getView() != null)
                     Snackbar.make(getView(), R.string.headlines_row_top_changed, Snackbar.LENGTH_LONG)
                             .setAction(R.string.reload, v -> refresh(false)).show();
 


### PR DESCRIPTION
Add null check for getView() before creating Snackbar when first ID changes. The LiveData observer can fire after the fragment's view is destroyed, causing a crash when trying to show the Snackbar.

Crash observed during usage.