### PR TITLE
Add split mode (image left, text right) to HeadlinesFragment

### DIFF
--- a/org.fox.ttrss/src/main/java/org/fox/ttrss/HeadlinesFragment.java
+++ b/org.fox.ttrss/src/main/java/org/fox/ttrss/HeadlinesFragment.java
@@ -113,6 +113,7 @@ public class HeadlinesFragment extends androidx.fragment.app.Fragment {
     private OnlineActivity m_activity;
     private SwipeRefreshLayout m_swipeLayout;
     private boolean m_compactLayoutMode = false;
+    private boolean m_splitLayoutMode = false;
     private RecyclerView m_list;
     private LinearLayoutManager m_layoutManager;
     private HeadlinesFragmentModel m_headlinesFragmentModel;
@@ -226,6 +227,7 @@ public class HeadlinesFragment extends androidx.fragment.app.Fragment {
             m_feed = savedInstanceState.getParcelable("m_feed");
             m_searchQuery = savedInstanceState.getString("m_searchQuery");
             m_compactLayoutMode = savedInstanceState.getBoolean("m_compactLayoutMode");
+            m_splitLayoutMode = savedInstanceState.getBoolean("m_splitLayoutMode");
         }
 
         setRetainInstance(true);
@@ -240,6 +242,7 @@ public class HeadlinesFragment extends androidx.fragment.app.Fragment {
         out.putParcelable("m_feed", m_feed);
         out.putString("m_searchQuery", m_searchQuery);
         out.putBoolean("m_compactLayoutMode", m_compactLayoutMode);
+        out.putBoolean("m_splitLayoutMode", m_splitLayoutMode);
     }
 
     @Override
@@ -252,6 +255,9 @@ public class HeadlinesFragment extends androidx.fragment.app.Fragment {
 
         if ("HL_COMPACT".equals(headlineMode) || "HL_COMPACT_NOIMAGES".equals(headlineMode))
             m_compactLayoutMode = true;
+
+        if ("HL_SPLIT".equals(headlineMode))
+            m_splitLayoutMode = true;
 
         DisplayMetrics metrics = new DisplayMetrics();
         getActivity().getWindowManager().getDefaultDisplay().getMetrics(metrics);
@@ -718,7 +724,7 @@ public class HeadlinesFragment extends androidx.fragment.app.Fragment {
             m_screenWidth = size.x;
 
             String headlineMode = m_prefs.getString("headline_mode", "HL_DEFAULT");
-            m_flavorImageEnabled = "HL_DEFAULT".equals(headlineMode) || "HL_COMPACT".equals(headlineMode);
+            m_flavorImageEnabled = "HL_DEFAULT".equals(headlineMode) || "HL_COMPACT".equals(headlineMode) || "HL_SPLIT".equals(headlineMode);
 
             m_colorPrimary = colorFromAttr(R.attr.colorPrimary);
             m_colorSecondary = colorFromAttr(R.attr.colorSecondary);
@@ -746,7 +752,12 @@ public class HeadlinesFragment extends androidx.fragment.app.Fragment {
         @Override
         public ArticleViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
 
-            int layoutId = m_compactLayoutMode ? R.layout.headlines_row_compact : R.layout.headlines_row;
+            int layoutId = R.layout.headlines_row;
+            if (m_compactLayoutMode) {
+                layoutId = R.layout.headlines_row_compact;
+            } else if (m_splitLayoutMode) {
+                layoutId = R.layout.headlines_row_split;
+            }
 
             if (viewType == VIEW_AMR_FOOTER) {
                 layoutId = R.layout.headlines_footer;
@@ -1100,7 +1111,7 @@ public class HeadlinesFragment extends androidx.fragment.app.Fragment {
                 holder.flavorImageHolder.setVisibility(View.GONE);
 
                 if (canShowFlavorImage() && article.flavorImageUri != null && holder.flavorImageView != null) {
-                    int maxImageHeight = (int) (m_screenHeight * 0.5f);
+                    int maxImageHeight = m_splitLayoutMode ? 150 : (int) (m_screenHeight * 0.5f);
 
                     // we also downsample below using glide to save RAM
                     holder.flavorImageView.setMaxHeight(maxImageHeight);

--- a/org.fox.ttrss/src/main/res/values/arrays.xml
+++ b/org.fox.ttrss/src/main/res/values/arrays.xml
@@ -14,12 +14,14 @@
         <item>@string/headline_display_mode_no_images</item>
         <item>@string/headline_display_mode_compact</item>
         <item>@string/headline_display_mode_compact_noimages</item>
+        <item>@string/headline_display_mode_split</item>
     </string-array>
     <string-array name="headline_mode_values" translatable="false">
         <item>HL_DEFAULT</item>
         <item>HL_NOIMAGES</item>
         <item>HL_COMPACT</item>
         <item>HL_COMPACT_NOIMAGES</item>
+        <item>HL_SPLIT</item>
     </string-array>
     <string-array name="pref_offline_amounts" translatable="false">
         <item>150</item>

--- a/org.fox.ttrss/src/main/res/values/strings.xml
+++ b/org.fox.ttrss/src/main/res/values/strings.xml
@@ -221,6 +221,7 @@
     <string name="headline_display_mode_no_images">No images</string>
     <string name="headline_display_mode_compact">Compact</string>
     <string name="headline_display_mode_compact_noimages">Compact (no images)</string>
+    <string name="headline_display_mode_split">Split view: image left, text right</string>
     <string name="prefs_version">%1$s (%2$d)</string>
     <string name="prefs_version_title">Version</string>
     <string name="prefs_build_timestamp">%1$s</string>


### PR DESCRIPTION
On large screen, if image takes full width it reduces the number of headlines displayed per page. A split screen enables to pack more headlines.