### PR TITLE
Restore article list after background process death

### DIFF
--- a/org.fox.ttrss/src/main/java/org/fox/ttrss/Application.java
+++ b/org.fox.ttrss/src/main/java/org/fox/ttrss/Application.java
@@ -1,9 +1,12 @@
 package org.fox.ttrss;
 
 import android.content.Context;
+import android.content.SharedPreferences;
 import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
 import android.os.Bundle;
+
+import androidx.preference.PreferenceManager;
 
 import com.google.android.material.color.DynamicColors;
 
@@ -20,6 +23,9 @@ import java.util.LinkedHashMap;
 import java.util.List;
 
 public class Application extends android.app.Application {
+
+    private static final String PREF_SESSION_ID = "gs:sessionId";
+    private static final String PREF_API_LEVEL = "gs:apiLevel";
 
     private static Application m_singleton;
 
@@ -50,6 +56,12 @@ public class Application extends android.app.Application {
         m_singleton = this;
         m_cmgr = (ConnectivityManager) getSystemService(Context.CONNECTIVITY_SERVICE);
         m_articleModel = new ArticleModel(this);
+
+        // Rehydrate session state that survives process death so that activities
+        // restored from savedInstanceState can resume without forcing a re-login.
+        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(this);
+        m_sessionId = prefs.getString(PREF_SESSION_ID, null);
+        m_apiLevel = prefs.getInt(PREF_API_LEVEL, 0);
     }
 
     public String getSessionId() {
@@ -58,6 +70,10 @@ public class Application extends android.app.Application {
 
     public void setSessionId(String sessionId) {
         m_sessionId = sessionId;
+        PreferenceManager.getDefaultSharedPreferences(this)
+                .edit()
+                .putString(PREF_SESSION_ID, sessionId)
+                .apply();
     }
 
     public int getApiLevel() {
@@ -66,6 +82,10 @@ public class Application extends android.app.Application {
 
     public void setApiLevel(int apiLevel) {
         m_apiLevel = apiLevel;
+        PreferenceManager.getDefaultSharedPreferences(this)
+                .edit()
+                .putInt(PREF_API_LEVEL, apiLevel)
+                .apply();
     }
 
     public void save(Bundle out) {

--- a/org.fox.ttrss/src/main/java/org/fox/ttrss/HeadlinesFragment.java
+++ b/org.fox.ttrss/src/main/java/org/fox/ttrss/HeadlinesFragment.java
@@ -282,7 +282,12 @@ public class HeadlinesFragment extends androidx.fragment.app.Fragment {
         m_adapter = new ArticleListAdapter();
         m_list.setAdapter(m_adapter);
 
-        if (savedInstanceState == null && Application.getArticles().isEmpty()) {
+        // Refresh whenever the in-memory article list is empty. Previously this
+        // was gated on `savedInstanceState == null` to avoid double-fetching on
+        // rotation, but that also suppressed the refresh after process death,
+        // when Android restores the activity with a saved Bundle even though
+        // ArticleModel has been reconstructed empty.
+        if (Application.getArticles().isEmpty()) {
             refresh(false);
         }
 


### PR DESCRIPTION
Android may kill the app's process while it's backgrounded and later recreate the activity from savedInstanceState. Two bugs combined to leave the user staring at a blank list (or a forced re-login) after this kind of restore:

1. Application held the session id only in memory, so a recreated process started with no credentials and the next API call failed with NOT_LOGGED_IN.
2. HeadlinesFragment's initial fetch was gated on `savedInstanceState == null`, intended to skip double-fetching on rotation. After process death the saved Bundle is non-null but ArticleModel has been reconstructed empty, so the guard suppressed the refresh that should have repopulated the list.

Persist the session id (and api level) through SharedPreferences so it survives process death, and refresh HeadlinesFragment whenever the in-memory article list is empty regardless of saved state. Rotation is still single-fetch because the singleton ArticleModel keeps the list populated across configuration changes.