### PR TITLE
Localize special feed titles from server strings

### DIFF
--- a/org.fox.ttrss/src/main/java/org/fox/ttrss/FeedsModel.java
+++ b/org.fox.ttrss/src/main/java/org/fox/ttrss/FeedsModel.java
@@ -120,6 +120,15 @@ public class FeedsModel extends AndroidViewModel implements ApiCommon.ApiCaller 
                     // seems to be necessary evil because of deserialization
                     feedsJson = feedsJson.stream().peek(Feed::fixNullFields).collect(Collectors.toList());
 
+                    // replace server-provided titles with localized strings for special feeds
+                    for (Feed f : feedsJson) {
+                        try {
+                            f.title = getApplication().getString(Feed.getSpecialFeedTitleId(f.id, f.is_cat));
+                        } catch (IllegalArgumentException ignored) {
+                            // not a special feed, keep server-provided title
+                        }
+                    }
+
                     if (unreadOnly && m_feed.id != Feed.CAT_SPECIAL)
                         feedsJson = feedsJson.stream()
                                 .filter(f -> f.unread > 0)

--- a/org.fox.ttrss/src/main/java/org/fox/ttrss/RootCategoriesModel.java
+++ b/org.fox.ttrss/src/main/java/org/fox/ttrss/RootCategoriesModel.java
@@ -65,6 +65,15 @@ public class RootCategoriesModel extends FeedsModel {
                         // seems to be necessary evil because of deserialization
                         feedsJson = feedsJson.stream().peek(Feed::fixNullFields).collect(Collectors.toList());
 
+                        // replace server-provided titles with localized strings for special feeds
+                        for (Feed f : feedsJson) {
+                            try {
+                                f.title = getApplication().getString(Feed.getSpecialFeedTitleId(f.id, f.is_cat));
+                            } catch (IllegalArgumentException ignored) {
+                                // not a special feed, keep server-provided title
+                            }
+                        }
+
                         sortFeeds(feedsJson, m_feed, new SpecialOrderComparator());
 
                         feedsCombined.addAll(feedsJson);


### PR DESCRIPTION
The special feed names ("All articles", "Fresh articles", etc.) were displayed using the server's language rather than the app's locale, because the titles from the API response were used directly. This replaces them with the existing localized string resources.