### PR TITLE
Add preference to disable swiping between articles

### DIFF
--- a/org.fox.ttrss/src/main/java/org/fox/ttrss/ArticlePager.java
+++ b/org.fox.ttrss/src/main/java/org/fox/ttrss/ArticlePager.java
@@ -2,6 +2,7 @@ package org.fox.ttrss;
 
 import android.annotation.SuppressLint;
 import android.app.Activity;
+import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.util.Log;
 import android.view.LayoutInflater;
@@ -10,6 +11,7 @@ import android.view.ViewGroup;
 
 import androidx.annotation.NonNull;
 import androidx.fragment.app.Fragment;
+import androidx.preference.PreferenceManager;
 import androidx.viewpager2.widget.ViewPager2;
 
 import org.fox.ttrss.types.Article;
@@ -102,6 +104,9 @@ public class ArticlePager extends androidx.fragment.app.Fragment {
 
         m_pager.setAdapter(m_adapter);
         m_pager.setOffscreenPageLimit(3);
+
+        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(getActivity());
+        m_pager.setUserInputEnabled(prefs.getBoolean("move_between_articles", true));
 
         m_pager.registerOnPageChangeCallback(new ViewPager2.OnPageChangeCallback() {
             @Override

--- a/org.fox.ttrss/src/main/res/values/strings.xml
+++ b/org.fox.ttrss/src/main/res/values/strings.xml
@@ -113,6 +113,8 @@
     <string name="category_browse_headlines">Browse headlines</string>
     <string name="use_volume_keys">Use volume buttons</string>
     <string name="use_volume_keys_long">Navigate articles and scroll headlines with hardware volume buttons</string>
+    <string name="move_between_articles">Move between articles</string>
+    <string name="move_between_articles_long">Navigate articles by swiping left and right</string>
     <string name="ssl_trust_any_host">No hostname verification</string>
     <string name="error_api_unknown_method">Error: unknown API method</string>
     <string name="ssl_trust_any_long">Accepts any SSL certificate without validation</string>

--- a/org.fox.ttrss/src/main/res/xml/preferences.xml
+++ b/org.fox.ttrss/src/main/res/xml/preferences.xml
@@ -187,6 +187,11 @@
             android:title="@string/use_volume_keys" />
         <SwitchPreferenceCompat
             android:defaultValue="true"
+            android:key="move_between_articles"
+            android:summary="@string/move_between_articles_long"
+            android:title="@string/move_between_articles" />
+        <SwitchPreferenceCompat
+            android:defaultValue="true"
             android:key="enable_article_fab"
             android:summary="@string/prefs_enable_fab_long"
             android:title="@string/prefs_enable_fab" />


### PR DESCRIPTION
When disabled, horizontal swipes in the article viewer (moving to the next or previous article) are suppressed.

I often trigger this navigation accidentally, and have found it more of a nuisance than a feature.  The default is enabled, which retains the existing behaviour.

I'm not sure if there are any other side-effects of disabling "user input" entirely, but volume key navigation and going back to pick another article both continue to work as normal, as does scrolling content inside the web view.