### PR TITLE
Enable pinch-to-zoom and panning in article view

### DIFF
--- a/org.fox.ttrss/src/main/java/org/fox/ttrss/ArticleFragment.java
+++ b/org.fox.ttrss/src/main/java/org/fox/ttrss/ArticleFragment.java
@@ -235,6 +235,14 @@ public class ArticleFragment extends androidx.fragment.app.Fragment {
 
                 return false;
             }
+
+            @Override
+            public void onScaleChanged(WebView view, float oldScale, float newScale) {
+                super.onScaleChanged(view, oldScale, newScale);
+                if (m_web instanceof ZoomableNestedScrollWebView) {
+                    ((ZoomableNestedScrollWebView) m_web).setCurrentScale(newScale);
+                }
+            }
         });
 
         m_web.setOnLongClickListener(v -> {
@@ -261,7 +269,9 @@ public class ArticleFragment extends androidx.fragment.app.Fragment {
         Log.d(TAG, "renderContent: " + m_article.title);
 
         WebSettings ws = m_web.getSettings();
-        ws.setSupportZoom(false);
+        ws.setSupportZoom(true);
+        ws.setBuiltInZoomControls(true);
+        ws.setDisplayZoomControls(false);
 
         TypedValue tvTextColor = new TypedValue();
         getActivity().getTheme().resolveAttribute(R.attr.colorOnSurface, tvTextColor, true);
@@ -298,7 +308,7 @@ public class ArticleFragment extends androidx.fragment.app.Fragment {
         StringBuilder content = new StringBuilder("<html>" +
                 "<head>" +
                 "<meta content=\"text/html; charset=utf-8\" http-equiv=\"content-type\">" +
-                "<meta name=\"viewport\" content=\"width=device-width, user-scalable=no\" />" +
+                "<meta name=\"viewport\" content=\"width=device-width\" />" +
                 "<style type=\"text/css\">" +
                 "body { padding : 0px; margin : " + margin8dp + "px; line-height : 1.3; word-wrap: break-word; }" +
                 "h1, h2, h3, h4, h5, h6 { line-height: 1; text-align: initial; }" +

--- a/org.fox.ttrss/src/main/java/org/fox/ttrss/ZoomableNestedScrollWebView.java
+++ b/org.fox.ttrss/src/main/java/org/fox/ttrss/ZoomableNestedScrollWebView.java
@@ -1,0 +1,65 @@
+package org.fox.ttrss;
+
+import android.content.Context;
+import android.util.AttributeSet;
+import android.view.MotionEvent;
+
+import com.telefonica.nestedscrollwebview.NestedScrollWebView;
+
+// NestedScrollWebView runs its own scrollBy in onNestedTouchEvent, which fights
+// WebView's native pinch-pan when the page is zoomed. This subclass skips that
+// nested path during pinch or while zoomed so pan works, then resumes nested
+// scrolling at base scale so the AppBarLayout still collapses on scroll.
+public class ZoomableNestedScrollWebView extends NestedScrollWebView {
+    private float m_scale = 1f;
+    private float m_baseScale = 0f;
+    private boolean m_skipping = false;
+
+    public ZoomableNestedScrollWebView(Context context) {
+        super(context);
+        setBlockNestedScrollingOnInternalContentScrollsEnabled(false);
+    }
+
+    public ZoomableNestedScrollWebView(Context context, AttributeSet attrs) {
+        super(context, attrs);
+        setBlockNestedScrollingOnInternalContentScrollsEnabled(false);
+    }
+
+    public ZoomableNestedScrollWebView(Context context, AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+        setBlockNestedScrollingOnInternalContentScrollsEnabled(false);
+    }
+
+    public void setCurrentScale(float scale) {
+        if (m_baseScale == 0f || scale < m_baseScale) {
+            m_baseScale = scale;
+        }
+        m_scale = scale;
+    }
+
+    public void resetBaseScale() {
+        m_baseScale = 0f;
+        m_scale = 1f;
+    }
+
+    @Override
+    public void onNestedTouchEvent(MotionEvent event) {
+        int action = event.getActionMasked();
+        if (action == MotionEvent.ACTION_DOWN) {
+            m_skipping = false;
+        }
+        float threshold = (m_baseScale > 0f ? m_baseScale : 1f) * 1.05f;
+        boolean shouldSkip = event.getPointerCount() > 1 || m_scale > threshold;
+        if (shouldSkip) {
+            if (!m_skipping) {
+                m_skipping = true;
+                MotionEvent cancel = MotionEvent.obtain(event);
+                cancel.setAction(MotionEvent.ACTION_CANCEL);
+                super.onNestedTouchEvent(cancel);
+                cancel.recycle();
+            }
+            return;
+        }
+        super.onNestedTouchEvent(event);
+    }
+}

--- a/org.fox.ttrss/src/main/res/layout/fragment_article.xml
+++ b/org.fox.ttrss/src/main/res/layout/fragment_article.xml
@@ -150,7 +150,7 @@
 
     </com.google.android.material.appbar.AppBarLayout>
 
-    <com.telefonica.nestedscrollwebview.NestedScrollWebView
+    <org.fox.ttrss.ZoomableNestedScrollWebView
         android:id="@+id/article_content"
         app:layout_behavior="@string/appbar_scrolling_view_behavior"
         android:layout_width="match_parent"


### PR DESCRIPTION
Allow users to zoom and pan article content in the WebView while preserving the app bar collapse-on-scroll behavior. A ZoomableNestedScrollWebView subclass suppresses the nested-scroll touch path while zoomed or pinching, so WebView's native pan is not overridden by the library's scrollBy handling. A small tolerance on the baseline scale accounts for WebView reporting a non-exact 1.0 after pinch-out.