### PR TITLE
Replace deprecated legacy-support-v4 with swiperefreshlayout

### DIFF
--- a/org.fox.ttrss/build.gradle
+++ b/org.fox.ttrss/build.gradle
@@ -144,7 +144,7 @@ dependencies {
     annotationProcessor 'com.github.bumptech.glide:compiler:5.0.5'
     implementation 'androidx.recyclerview:recyclerview:1.4.0'
     implementation 'androidx.activity:activity:1.13.0'
-    implementation 'androidx.legacy:legacy-support-v4:1.0.0'
+    implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.1.0'
     implementation 'androidx.appcompat:appcompat:1.7.1'
     implementation 'androidx.appcompat:appcompat-resources:1.7.1'
     implementation 'androidx.browser:browser:1.10.0'


### PR DESCRIPTION
The androidx.legacy:legacy-support-v4 umbrella is frozen and deprecated. SwipeRefreshLayout (used by HeadlinesFragment and LogcatActivity) is the only piece actually needed; depend on it directly instead.