### PR TITLE
Pin NestedScrollCoordinatorLayout to tagged release 1.0.3

### DIFF
--- a/org.fox.ttrss/build.gradle
+++ b/org.fox.ttrss/build.gradle
@@ -149,7 +149,7 @@ dependencies {
     implementation 'androidx.appcompat:appcompat-resources:1.7.1'
     implementation 'androidx.browser:browser:1.10.0'
     implementation 'androidx.coordinatorlayout:coordinatorlayout:1.3.0'
-    implementation 'com.github.natario1:NestedScrollCoordinatorLayout:5a33a7dbd8'
+    implementation 'com.github.natario1:NestedScrollCoordinatorLayout:1.0.3'
     implementation 'com.google.android.material:material:1.13.0'
     implementation 'com.google.code.gson:gson:2.13.2'
     implementation 'me.relex:circleindicator:2.1.6'


### PR DESCRIPTION
Using a commit SHA is opaque to version scanners and makes upgrades harder to reason about. 1.0.3 is the latest tag on JitPack.