### PR TITLE
Use RSS icon as image-load fallback instead of letter drawable

### DIFF
--- a/org.fox.ttrss/src/main/java/org/fox/ttrss/HeadlinesFragment.java
+++ b/org.fox.ttrss/src/main/java/org/fox/ttrss/HeadlinesFragment.java
@@ -1524,7 +1524,7 @@ public class HeadlinesFragment extends androidx.fragment.app.Fragment {
                             .load(faviconUrl)
                             .transition(DrawableTransitionOptions.withCrossFade())
                             .placeholder(faviconBackground)
-                            .error(textDrawable)
+                            .error(R.drawable.baseline_rss_feed_24)
                             .diskCacheStrategy(DiskCacheStrategy.ALL)
                             .skipMemoryCache(false)
                             .into(holder.textImage);
@@ -1536,6 +1536,7 @@ public class HeadlinesFragment extends androidx.fragment.app.Fragment {
                             .load(article.flavorImageUri)
                             .transition(DrawableTransitionOptions.withCrossFade())
                             .placeholder(textDrawable)
+                            .error(R.drawable.baseline_rss_feed_24)
                             .thumbnail(0.5f)
                             .apply(RequestOptions.circleCropTransform())
                             .diskCacheStrategy(DiskCacheStrategy.ALL)


### PR DESCRIPTION
When Glide fails to load a favicon or flavor image, show the RSS feed glyph instead of the generated letter circle. The letter is still used for articles with no image URL at all.