### PR TITLE
Make RSS feed icon follow the theme

### DIFF
--- a/org.fox.ttrss/src/main/res/drawable/baseline_rss_feed_24.xml
+++ b/org.fox.ttrss/src/main/res/drawable/baseline_rss_feed_24.xml
@@ -1,4 +1,4 @@
-<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="#000000" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="?attr/colorOnSurface" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
       
     <path android:fillColor="@android:color/white" android:pathData="M6.18,17.82m-2.18,0a2.18,2.18 0,1 1,4.36 0a2.18,2.18 0,1 1,-4.36 0"/>
       


### PR DESCRIPTION
Replace the hardcoded black tint with ?attr/colorOnSurface so the icon renders correctly in dark mode.