### PR TITLE
Replace deprecated AsyncTask and Handler() no-arg constructor.

### DIFF
--- a/org.fox.ttrss/src/main/java/org/fox/ttrss/ApiRequest.java
+++ b/org.fox.ttrss/src/main/java/org/fox/ttrss/ApiRequest.java
@@ -2,19 +2,24 @@ package org.fox.ttrss;
 
 import static org.fox.ttrss.ApiCommon.ApiError;
 
-import android.annotation.SuppressLint;
 import android.content.Context;
-import android.os.AsyncTask;
+import android.os.Handler;
+import android.os.Looper;
 
 import com.google.gson.JsonElement;
 
 import java.util.HashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
-public class ApiRequest extends AsyncTask<HashMap<String, String>, Integer, JsonElement> implements ApiCommon.ApiCaller {
+public class ApiRequest implements ApiCommon.ApiCaller {
+
+    private static final ExecutorService EXECUTOR = Executors.newCachedThreadPool();
 
     protected int m_apiStatusCode = 0;
 
     private final Context m_context;
+    private final Handler m_mainHandler = new Handler(Looper.getMainLooper());
     protected String m_lastErrorMessage;
 
     protected ApiError m_lastError;
@@ -24,19 +29,18 @@ public class ApiRequest extends AsyncTask<HashMap<String, String>, Integer, Json
         m_lastError = ApiError.UNKNOWN_ERROR;
     }
 
-    @SuppressLint("NewApi")
-    @SuppressWarnings("unchecked")
     public void execute(HashMap<String, String> map) {
-        super.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR, map);
+        EXECUTOR.submit(() -> {
+            final JsonElement result = ApiCommon.performRequest(m_context, map, this);
+            m_mainHandler.post(() -> onPostExecute(result));
+        });
+    }
+
+    protected void onPostExecute(JsonElement result) {
     }
 
     public int getErrorMessage() {
         return ApiCommon.getErrorMessage(m_lastError);
-    }
-
-    @Override
-    protected JsonElement doInBackground(HashMap<String, String>... params) {
-        return ApiCommon.performRequest(m_context, params[0], this);
     }
 
     @Override
@@ -56,6 +60,5 @@ public class ApiRequest extends AsyncTask<HashMap<String, String>, Integer, Json
 
     @Override
     public void notifyProgress(int progress) {
-        publishProgress(progress);
     }
 }

--- a/org.fox.ttrss/src/main/java/org/fox/ttrss/HeadlinesFragment.java
+++ b/org.fox.ttrss/src/main/java/org/fox/ttrss/HeadlinesFragment.java
@@ -17,6 +17,7 @@ import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
+import android.os.Looper;
 import android.text.Html;
 import android.transition.Fade;
 import android.transition.Transition;
@@ -388,7 +389,7 @@ public class HeadlinesFragment extends androidx.fragment.app.Fragment {
 
                         m_readArticles.clear();
 
-                        new Handler().postDelayed(() -> m_activity.refresh(false), 100);
+                        new Handler(Looper.getMainLooper()).postDelayed(() -> m_activity.refresh(false), 100);
                     }
                 }
             }
@@ -431,7 +432,7 @@ public class HeadlinesFragment extends androidx.fragment.app.Fragment {
                     final Feed feedToLoad = m_feed;
 
                     // this has to be dispatched delayed, consequent adapter updates are forbidden in scroll handler
-                    new Handler().postDelayed(() -> {
+                    new Handler(Looper.getMainLooper()).postDelayed(() -> {
                         if (feedToLoad.equals(m_feed)) {
                             refresh(true);
                         }
@@ -478,7 +479,7 @@ public class HeadlinesFragment extends androidx.fragment.app.Fragment {
                         final Feed feedToLoad = m_feed;
 
                         // this has to be dispatched delayed, consequent adapter updates are forbidden in scroll handler
-                        new Handler().postDelayed(() -> {
+                        new Handler(Looper.getMainLooper()).postDelayed(() -> {
                             if (feedToLoad.equals(m_feed)) {
                                 refresh(true);
                             }
@@ -1688,7 +1689,7 @@ public class HeadlinesFragment extends androidx.fragment.app.Fragment {
                 Log.d(TAG, "marking articles as read, count=" + m_readArticles.size());
                 m_activity.setArticlesUnread(new ArrayList<>(m_readArticles), Article.UPDATE_SET_FALSE);
                 m_readArticles.clear();
-                new Handler().postDelayed(() -> m_activity.refresh(false), 100);
+                new Handler(Looper.getMainLooper()).postDelayed(() -> m_activity.refresh(false), 100);
             }
         }
     }

--- a/org.fox.ttrss/src/main/java/org/fox/ttrss/MasterActivity.java
+++ b/org.fox.ttrss/src/main/java/org/fox/ttrss/MasterActivity.java
@@ -467,6 +467,7 @@ public class MasterActivity extends OnlineActivity implements HeadlinesEventList
 
     public void unsubscribeFeed(final Feed feed) {
         ApiRequest req = new ApiRequest(getApplicationContext()) {
+            @Override
             protected void onPostExecute(JsonElement result) {
                 refresh();
             }

--- a/org.fox.ttrss/src/main/java/org/fox/ttrss/OnlineActivity.java
+++ b/org.fox.ttrss/src/main/java/org/fox/ttrss/OnlineActivity.java
@@ -926,6 +926,7 @@ public class OnlineActivity extends CommonActivity {
         Log.d(TAG, "catchupFeed=" + feed + "; mode=" + mode + "; search=" + searchQuery);
 
         ApiRequest req = new ApiRequest(getApplicationContext()) {
+            @Override
             protected void onPostExecute(JsonElement result) {
                 if (refreshAfter)
                     refresh();
@@ -994,6 +995,7 @@ public class OnlineActivity extends CommonActivity {
 
     public void setArticlesField(final List<Article> articles, int field, int mode) {
         ApiRequest req = new ApiRequest(getApplicationContext()) {
+            @Override
             protected void onPostExecute(JsonElement result) {
                 if (m_lastError == ApiCommon.ApiError.SUCCESS) {
 
@@ -1177,6 +1179,7 @@ public class OnlineActivity extends CommonActivity {
             m_listener = listener;
         }
 
+        @Override
         @SuppressLint("StaticFieldLeak")
         protected void onPostExecute(JsonElement result) {
             if (result != null) {
@@ -1214,6 +1217,7 @@ public class OnlineActivity extends CommonActivity {
                         } else {
 
                             ApiRequest req = new ApiRequest(OnlineActivity.this) {
+                                @Override
                                 protected void onPostExecute(JsonElement result) {
                                     setApiLevel(0);
 

--- a/org.fox.ttrss/src/main/java/org/fox/ttrss/widget/WidgetUpdateService.java
+++ b/org.fox.ttrss/src/main/java/org/fox/ttrss/widget/WidgetUpdateService.java
@@ -10,6 +10,7 @@ import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
 import android.os.Build;
 import android.os.Handler;
+import android.os.Looper;
 import android.util.Log;
 import android.widget.RemoteViews;
 
@@ -58,7 +59,7 @@ public class WidgetUpdateService extends JobIntentService {
                 Log.d(TAG, "service update requested but network is not available, try: " + retryCount);
 
                 if (retryCount < 10) {
-                    new Handler().postDelayed(() -> {
+                    new Handler(Looper.getMainLooper()).postDelayed(() -> {
                         Intent serviceIntent = new Intent(getApplicationContext(), WidgetUpdateService.class);
                         serviceIntent.putExtra("retryCount", retryCount + 1);
 


### PR DESCRIPTION
ApiRequest now uses a cached ExecutorService and a main-thread Handler instead of extending AsyncTask (deprecated in API 30). Remaining new Handler() call sites in HeadlinesFragment and WidgetUpdateService are updated to pass Looper.getMainLooper() explicitly. Adds missing @Override annotations on onPostExecute subclass methods.