### PR TITLE
Address F-Droid CI scan findings.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,6 @@ allprojects {
         google()
         mavenCentral()
         maven { url = "https://clojars.org/repo/" }
-        maven { url = "https://jzaccone.github.io/SlidingMenu-aar" }
         maven { url = "https://jitpack.io" }
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
+distributionSha256Sum=2ab2958f2a1e51120c326cad6f385153bb11ee93b3c216c5fccebfdfbb7ec6cb
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,2 @@
-plugins {
-    id 'org.gradle.toolchains.foojay-resolver-convention' version '1.0.0'
-}
 include ':org.fox.ttrss'
 rootProject.name='Tiny Tiny RSS for Android'


### PR DESCRIPTION
Remove unused foojay-resolver plugin and SlidingMenu-aar maven repo, and pin the Gradle distribution SHA-256.