### PR TITLE
Fix resource leaks in ApiCommon, CommonActivity, LogcatActivity, Gall…

### DIFF
--- a/org.fox.ttrss/src/main/java/org/fox/ttrss/ApiCommon.java
+++ b/org.fox.ttrss/src/main/java/org/fox/ttrss/ApiCommon.java
@@ -172,77 +172,78 @@ public class ApiCommon {
                     .addNetworkInterceptor(createInterceptor(listener))
                     .build();
 
-            Response response = client.newCall(request).execute();
+            try (Response response = client.newCall(request).execute()) {
 
-            if (response.isSuccessful()) {
-                String payloadReceived = response.body().string();
+                if (response.isSuccessful()) {
+                    String payloadReceived = response.body().string();
 
-                if (m_transportDebugging) Log.d(TAG, "<<< " + payloadReceived);
+                    if (m_transportDebugging) Log.d(TAG, "<<< " + payloadReceived);
 
-                JsonElement result = JsonParser.parseString(payloadReceived);
-                JsonObject resultObj = result.getAsJsonObject();
+                    JsonElement result = JsonParser.parseString(payloadReceived);
+                    JsonObject resultObj = result.getAsJsonObject();
 
-                int statusCode = resultObj.get("status").getAsInt();
+                    int statusCode = resultObj.get("status").getAsInt();
 
-                caller.setStatusCode(statusCode);
+                    caller.setStatusCode(statusCode);
 
-                switch (statusCode) {
-                    case API_STATUS_OK:
-                        caller.setLastError(ApiError.SUCCESS);
-                        return result.getAsJsonObject().get("content");
-                    case API_STATUS_ERR:
-                        JsonObject contentObj = resultObj.get("content").getAsJsonObject();
-                        String error = contentObj.get("error").getAsString();
+                    switch (statusCode) {
+                        case API_STATUS_OK:
+                            caller.setLastError(ApiError.SUCCESS);
+                            return result.getAsJsonObject().get("content");
+                        case API_STATUS_ERR:
+                            JsonObject contentObj = resultObj.get("content").getAsJsonObject();
+                            String error = contentObj.get("error").getAsString();
 
-                        switch (error) {
-                            case "LOGIN_ERROR":
-                            case "NOT_LOGGED_IN":
-                                caller.setLastError(ApiError.LOGIN_FAILED);
-                                break;
-                            case "API_DISABLED":
-                                caller.setLastError(ApiError.API_DISABLED);
-                                break;
-                            case "INCORRECT_USAGE":
-                                caller.setLastError(ApiError.API_INCORRECT_USAGE);
-                                break;
-                            case "UNKNOWN_METHOD":
-                                caller.setLastError(ApiError.API_UNKNOWN_METHOD);
-                                break;
-                            default:
-                                Log.d(TAG, "Unknown API error: " + error);
-                                caller.setLastErrorMessage(error);
-                                caller.setLastError(ApiError.API_UNKNOWN);
-                                break;
-                        }
+                            switch (error) {
+                                case "LOGIN_ERROR":
+                                case "NOT_LOGGED_IN":
+                                    caller.setLastError(ApiError.LOGIN_FAILED);
+                                    break;
+                                case "API_DISABLED":
+                                    caller.setLastError(ApiError.API_DISABLED);
+                                    break;
+                                case "INCORRECT_USAGE":
+                                    caller.setLastError(ApiError.API_INCORRECT_USAGE);
+                                    break;
+                                case "UNKNOWN_METHOD":
+                                    caller.setLastError(ApiError.API_UNKNOWN_METHOD);
+                                    break;
+                                default:
+                                    Log.d(TAG, "Unknown API error: " + error);
+                                    caller.setLastErrorMessage(error);
+                                    caller.setLastError(ApiError.API_UNKNOWN);
+                                    break;
+                            }
+                    }
+
+                } else {
+                    switch (response.code()) {
+                        case 400:
+                            caller.setLastError(ApiError.HTTP_BAD_REQUEST);
+                            break;
+                        case 401:
+                            caller.setLastError(ApiError.HTTP_UNAUTHORIZED);
+                            break;
+                        case 403:
+                            caller.setLastError(ApiError.HTTP_FORBIDDEN);
+                            break;
+                        case 404:
+                            caller.setLastError(ApiError.HTTP_NOT_FOUND);
+                            break;
+                        case 500:
+                        case 501:
+                            caller.setLastError(ApiError.HTTP_SERVER_ERROR);
+                            break;
+                        default:
+                            Log.d(TAG, "HTTP response code: " + response.code());
+                            caller.setLastErrorMessage("HTTP response code: " + response.code());
+                            caller.setLastError(ApiError.HTTP_OTHER_ERROR);
+                            break;
+                    }
                 }
 
-            } else {
-                switch (response.code()) {
-                    case 400:
-                        caller.setLastError(ApiError.HTTP_BAD_REQUEST);
-                        break;
-                    case 401:
-                        caller.setLastError(ApiError.HTTP_UNAUTHORIZED);
-                        break;
-                    case 403:
-                        caller.setLastError(ApiError.HTTP_FORBIDDEN);
-                        break;
-                    case 404:
-                        caller.setLastError(ApiError.HTTP_NOT_FOUND);
-                        break;
-                    case 500:
-                    case 501:
-                        caller.setLastError(ApiError.HTTP_SERVER_ERROR);
-                        break;
-                    default:
-                        Log.d(TAG, "HTTP response code: " + response.code());
-                        caller.setLastErrorMessage("HTTP response code: " + response.code());
-                        caller.setLastError(ApiError.HTTP_OTHER_ERROR);
-                        break;
-                }
+                return null;
             }
-
-            return null;
         } catch (javax.net.ssl.SSLPeerUnverifiedException e) {
             caller.setLastError(ApiError.SSL_REJECTED);
             caller.setLastErrorMessage(e.getMessage());

--- a/org.fox.ttrss/src/main/java/org/fox/ttrss/CommonActivity.java
+++ b/org.fox.ttrss/src/main/java/org/fox/ttrss/CommonActivity.java
@@ -374,10 +374,10 @@ public class CommonActivity extends AppCompatActivity implements SharedPreferenc
 
                                 File file = new File(shareFolder, "shared.png");
 
-                                FileOutputStream stream = new FileOutputStream(file);
-                                resource.compress(Bitmap.CompressFormat.PNG, 90, stream);
-                                stream.flush();
-                                stream.close();
+                                try (FileOutputStream stream = new FileOutputStream(file)) {
+                                    resource.compress(Bitmap.CompressFormat.PNG, 90, stream);
+                                    stream.flush();
+                                }
 
                                 Uri shareUri = FileProvider.getUriForFile(CommonActivity.this,
                                         "org.fox.ttrss.SharedFileProvider", file);

--- a/org.fox.ttrss/src/main/java/org/fox/ttrss/GalleryVideoFragment.java
+++ b/org.fox.ttrss/src/main/java/org/fox/ttrss/GalleryVideoFragment.java
@@ -25,6 +25,7 @@ public class GalleryVideoFragment extends GalleryBaseFragment {
     String m_url;
     String m_coverUrl;
     MediaPlayer m_mediaPlayer;
+    Surface m_surface;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -89,7 +90,7 @@ public class GalleryVideoFragment extends GalleryBaseFragment {
         textureView.setSurfaceTextureListener(new TextureView.SurfaceTextureListener() {
             @Override
             public void onSurfaceTextureAvailable(SurfaceTexture surface, int width, int height) {
-                Surface s = new Surface(surface);
+                m_surface = new Surface(surface);
 
                 m_mediaPlayer = new MediaPlayer();
 
@@ -150,7 +151,7 @@ public class GalleryVideoFragment extends GalleryBaseFragment {
                     }
                 });
 
-                m_mediaPlayer.setSurface(s);
+                m_mediaPlayer.setSurface(m_surface);
 
                 try {
                     m_mediaPlayer.setDataSource(m_url);
@@ -186,6 +187,10 @@ public class GalleryVideoFragment extends GalleryBaseFragment {
                     m_mediaPlayer.release();
                 } catch (Exception e) {
                     e.printStackTrace();
+                }
+                if (m_surface != null) {
+                    m_surface.release();
+                    m_surface = null;
                 }
                 return false;
             }

--- a/org.fox.ttrss/src/main/java/org/fox/ttrss/LogcatActivity.java
+++ b/org.fox.ttrss/src/main/java/org/fox/ttrss/LogcatActivity.java
@@ -66,19 +66,23 @@ public class LogcatActivity extends CommonActivity {
     private void refresh() {
         m_items.clear();
 
+        Process process = null;
         try {
-            Process process = Runtime.getRuntime().exec("logcat -d -t " + MAX_LOG_ENTRIES);
-            BufferedReader bufferedReader = new BufferedReader(
-                    new InputStreamReader(process.getInputStream(), StandardCharsets.UTF_8));
+            process = Runtime.getRuntime().exec("logcat -d -t " + MAX_LOG_ENTRIES);
 
-            String line;
+            try (BufferedReader bufferedReader = new BufferedReader(
+                    new InputStreamReader(process.getInputStream(), StandardCharsets.UTF_8))) {
 
-            while ((line = bufferedReader.readLine()) != null) {
-                m_items.add(0, line);
+                String line;
+
+                while ((line = bufferedReader.readLine()) != null) {
+                    m_items.add(0, line);
+                }
             }
-
         } catch (Exception e) {
             m_items.add(e.toString());
+        } finally {
+            if (process != null) process.destroy();
         }
 
         if (m_adapter != null) m_adapter.notifyDataSetChanged();


### PR DESCRIPTION
…eryVideoFragment

Wrap the okhttp Response, bitmap-share FileOutputStream, and logcat reader in try-with-resources, destroy the logcat Process in a finally block, and explicitly release the GalleryVideoFragment Surface in onSurfaceTextureDestroyed, so these resources are released on all code paths rather than waiting on finalizers or leaking on exceptions.