### PR TITLE
Remove duplicate setAppTheme in Detail/MasterActivity onCreate

### DIFF
--- a/org.fox.ttrss/src/main/java/org/fox/ttrss/DetailActivity.java
+++ b/org.fox.ttrss/src/main/java/org/fox/ttrss/DetailActivity.java
@@ -3,7 +3,6 @@ package org.fox.ttrss;
 import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.content.Intent;
-import android.content.SharedPreferences;
 import android.net.Uri;
 import android.os.Bundle;
 import android.util.Log;
@@ -13,7 +12,6 @@ import android.view.View;
 
 import androidx.appcompat.widget.Toolbar;
 import androidx.fragment.app.FragmentTransaction;
-import androidx.preference.PreferenceManager;
 
 import com.google.android.material.bottomappbar.BottomAppBar;
 import com.google.android.material.floatingactionbutton.FloatingActionButton;
@@ -25,16 +23,9 @@ public class DetailActivity extends OnlineActivity implements HeadlinesEventList
     private static final String TAG = DetailActivity.class.getSimpleName();
     protected BottomAppBar m_bottomAppBar;
 
-    protected SharedPreferences m_prefs;
-
     @SuppressLint("NewApi")
     @Override
     public void onCreate(Bundle savedInstanceState) {
-        m_prefs = PreferenceManager
-                .getDefaultSharedPreferences(getApplicationContext());
-
-        setAppTheme(m_prefs);
-
         super.onCreate(savedInstanceState);
 
         if (m_prefs.getBoolean("force_phone_layout", false)) {

--- a/org.fox.ttrss/src/main/java/org/fox/ttrss/MasterActivity.java
+++ b/org.fox.ttrss/src/main/java/org/fox/ttrss/MasterActivity.java
@@ -20,7 +20,6 @@ import androidx.core.view.WindowInsetsCompat;
 import androidx.drawerlayout.widget.DrawerLayout;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentTransaction;
-import androidx.preference.PreferenceManager;
 
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import com.google.android.material.floatingactionbutton.FloatingActionButton;
@@ -38,7 +37,6 @@ public class MasterActivity extends OnlineActivity implements HeadlinesEventList
 
     private static final int HEADLINES_REQUEST = 1;
 
-    protected SharedPreferences m_prefs;
     protected long m_lastRefresh = 0;
     protected long m_lastWidgetRefresh = 0;
 
@@ -48,11 +46,6 @@ public class MasterActivity extends OnlineActivity implements HeadlinesEventList
     @SuppressLint("NewApi")
     @Override
     public void onCreate(Bundle savedInstanceState) {
-        m_prefs = PreferenceManager
-                .getDefaultSharedPreferences(getApplicationContext());
-
-        setAppTheme(m_prefs);
-
         super.onCreate(savedInstanceState);
 
         if (m_prefs.getBoolean("force_phone_layout", false)) {


### PR DESCRIPTION
Both subclasses fetched m_prefs and called setAppTheme before invoking super.onCreate, which (via OnlineActivity.onCreate) did the same thing again. The duplicate setTheme reapplied the theme graph twice per Activity creation, doubling theme-attribute resolution work and the associated "Invalid resource ID 0x00000000" noise from the native AssetManager on every DetailActivity entry.