### PR TITLE
Don't gate API requests on deprecated connectivity check.

### DIFF
--- a/org.fox.ttrss/src/main/java/org/fox/ttrss/ApiCommon.java
+++ b/org.fox.ttrss/src/main/java/org/fox/ttrss/ApiCommon.java
@@ -123,11 +123,6 @@ public class ApiCommon {
     static JsonElement performRequest(Context context, @NonNull HashMap<String, String> m_params,
                                       @NonNull ApiCommon.ApiCaller caller) {
         try {
-            if (!ApiCommon.isNetworkAvailable(context)) {
-                caller.setLastError(ApiError.NETWORK_UNAVAILABLE);
-                return null;
-            }
-
             SharedPreferences m_prefs = PreferenceManager.getDefaultSharedPreferences(context);
 
             boolean m_transportDebugging = m_prefs.getBoolean("transport_debugging", false);


### PR DESCRIPTION
getActiveNetworkInfo().isConnected() has been deprecated since API 29 and gives unreliable signals in common cases: captive portals, brief drops, Wi-Fi-associated-but-no-DNS, stale state on newer Android. The pre-flight gate caused spurious NETWORK_UNAVAILABLE errors in all of those cases, even when the request itself would have succeeded.

Since the same API is no more trustworthy for post-failure classification, drop its use from performRequest() entirely. Any network failure now surfaces as IO_ERROR; truly-offline users lose the slightly nicer NETWORK_UNAVAILABLE message but gain working requests on flaky real-world networks.

The helper remains for WidgetUpdateService's own retry loop.