### PR TITLE
Bump toolchain requirement to Java 21

### DIFF
--- a/.github/workflows/build-debug-apk.yml
+++ b/.github/workflows/build-debug-apk.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Set up Java
       uses: actions/setup-java@v5
       with:
-        java-version: 17
+        java-version: 21
         distribution: temurin
 
     - name: Set up Gradle

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Set up Java
       uses: actions/setup-java@v5
       with:
-        java-version: 17
+        java-version: 21
         distribution: temurin
 
     - name: Set up Gradle

--- a/org.fox.ttrss/build.gradle
+++ b/org.fox.ttrss/build.gradle
@@ -196,6 +196,6 @@ tasks.withType(JavaCompile).configureEach {
 }
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(17)
+        languageVersion = JavaLanguageVersion.of(21)
     }
 }


### PR DESCRIPTION
This unblocks the error-prone PR.  Note that this does not change the emitted bytecode.  References #108.