### PR TITLE
Surface uncaught exceptions from background API requests.

### DIFF
--- a/org.fox.ttrss/src/main/java/org/fox/ttrss/ApiRequest.java
+++ b/org.fox.ttrss/src/main/java/org/fox/ttrss/ApiRequest.java
@@ -30,7 +30,7 @@ public class ApiRequest implements ApiCommon.ApiCaller {
     }
 
     public void execute(HashMap<String, String> map) {
-        EXECUTOR.submit(() -> {
+        EXECUTOR.execute(() -> {
             final JsonElement result = ApiCommon.performRequest(m_context, map, this);
             m_mainHandler.post(() -> onPostExecute(result));
         });


### PR DESCRIPTION
ExecutorService.submit wraps the task in a Future that swallows exceptions when no one calls Future.get. Switch to execute so exceptions propagate to the thread's UncaughtExceptionHandler, and clear the error-prone FutureReturnValueIgnored warning.