### PR TITLE
Replace deprecated Display.getWidth/getHeight in isPortrait().

### DIFF
--- a/org.fox.ttrss/src/main/java/org/fox/ttrss/CommonActivity.java
+++ b/org.fox.ttrss/src/main/java/org/fox/ttrss/CommonActivity.java
@@ -13,6 +13,7 @@ import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.pm.PackageManager;
 import android.content.pm.ResolveInfo;
+import android.content.res.Configuration;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.net.Uri;
@@ -22,7 +23,6 @@ import android.os.SystemClock;
 import android.text.TextUtils;
 import android.util.DisplayMetrics;
 import android.util.Log;
-import android.view.Display;
 import android.view.View;
 import android.view.WindowManager;
 import android.widget.CheckBox;
@@ -269,14 +269,8 @@ public class CommonActivity extends AppCompatActivity implements SharedPreferenc
         return m_smallScreenMode;
     }
 
-    @SuppressWarnings("deprecation")
     public boolean isPortrait() {
-        Display display = getWindowManager().getDefaultDisplay();
-
-        int width = display.getWidth();
-        int height = display.getHeight();
-
-        return width < height;
+        return getResources().getConfiguration().orientation == Configuration.ORIENTATION_PORTRAIT;
     }
 
     @SuppressLint({"NewApi", "ServiceCast"})

--- a/org.fox.ttrss/src/main/java/org/fox/ttrss/share/CommonActivity.java
+++ b/org.fox.ttrss/src/main/java/org/fox/ttrss/share/CommonActivity.java
@@ -2,7 +2,6 @@ package org.fox.ttrss.share;
 
 import android.app.Activity;
 import android.util.Log;
-import android.view.Display;
 import android.widget.Toast;
 
 public class CommonActivity extends Activity {
@@ -28,15 +27,4 @@ public class CommonActivity extends Activity {
     public boolean isSmallScreen() {
         return m_smallScreenMode;
     }
-
-    public boolean isPortrait() {
-        Display display = getWindowManager().getDefaultDisplay();
-
-        int width = display.getWidth();
-        int height = display.getHeight();
-
-        return width < height;
-    }
-
-
 }


### PR DESCRIPTION
Display.getWidth/getHeight and Display.getDefaultDisplay have been deprecated since API 30. Read orientation directly from the resource Configuration instead, which is the canonical source the system uses for resource qualifiers and is correct under multi-window.

Also drop the unused duplicate isPortrait() in share.CommonActivity.