### PR TITLE
Fix lazy load pagination stalls and null API response crashes

### DIFF
--- a/org.fox.ttrss/src/main/java/org/fox/ttrss/ArticleModel.java
+++ b/org.fox.ttrss/src/main/java/org/fox/ttrss/ArticleModel.java
@@ -282,7 +282,7 @@ public class ArticleModel extends AndroidViewModel implements ApiCommon.ApiCalle
                                 Log.d(TAG, "duplicate:" + article);
                             }
 
-                        if (m_firstIdChanged) {
+                        if (m_firstIdChanged && !m_append) {
                             Log.d(TAG, "first id changed, disabling lazy load");
                             m_lazyLoadEnabled = false;
                         }
@@ -323,19 +323,15 @@ public class ArticleModel extends AndroidViewModel implements ApiCommon.ApiCalle
             int numUnread = Math.toIntExact(getUnread(articles).size());
             int numAll = Math.toIntExact(articles.size());
 
-            if ("marked".equals(viewMode)) {
-                skip = numAll;
-            } else if ("published".equals(viewMode)) {
-                skip = numAll;
-            } else if ("unread".equals(viewMode)) {
-                skip = numUnread;
-            } else if (m_searchQuery != null && !m_searchQuery.isEmpty()) {
-                skip = numAll;
-            } else if ("adaptive".equals(viewMode)) {
-                skip = numUnread > 0 ? numUnread : numAll;
-            } else {
-                skip = numAll;
-            }
+            // unread-only feeds (explicit unread view mode, and the Fresh
+            // virtual feed) shrink as articles are marked read, so paginate
+            // by numUnread there; adaptive mode does the same as long as
+            // unread articles remain, falling back to numAll once exhausted
+            boolean unreadOnlyPagination = "unread".equals(viewMode)
+                    || m_feed.id == Feed.FRESH
+                    || ("adaptive".equals(viewMode) && numUnread > 0);
+
+            skip = unreadOnlyPagination ? numUnread : numAll;
         }
 
         return skip;

--- a/org.fox.ttrss/src/main/java/org/fox/ttrss/FeedsModel.java
+++ b/org.fox.ttrss/src/main/java/org/fox/ttrss/FeedsModel.java
@@ -113,9 +113,10 @@ public class FeedsModel extends AndroidViewModel implements ApiCommon.ApiCaller 
 
             boolean unreadOnly = m_prefs.getBoolean("show_unread_only", true);
 
-            try {
-                JsonArray content = result.getAsJsonArray();
-                if (content != null) {
+            if (result != null) {
+                try {
+                    JsonArray content = result.getAsJsonArray();
+                    if (content != null) {
 
                     List<Feed> feedsJson = GSON.fromJson(content, FEED_LIST_TYPE);
 
@@ -139,12 +140,13 @@ public class FeedsModel extends AndroidViewModel implements ApiCommon.ApiCaller 
                     sortFeeds(feedsJson, m_feed, null);
 
                     m_feeds.postValue(feedsJson);
-                }
-            } catch (Exception e) {
-                setLastError(ApiCommon.ApiError.OTHER_ERROR);
-                setLastErrorMessage(e.getMessage());
+                    }
+                } catch (Exception e) {
+                    setLastError(ApiCommon.ApiError.OTHER_ERROR);
+                    setLastErrorMessage(e.getMessage());
 
-                e.printStackTrace();
+                    e.printStackTrace();
+                }
             }
 
             m_isLoading.postValue(false);

--- a/org.fox.ttrss/src/main/java/org/fox/ttrss/RootCategoriesModel.java
+++ b/org.fox.ttrss/src/main/java/org/fox/ttrss/RootCategoriesModel.java
@@ -55,33 +55,35 @@ public class RootCategoriesModel extends FeedsModel {
                 if (BuildConfig.DEBUG)
                     Log.d(TAG, "got result=" + result);
 
-                try {
-                    JsonArray content = result.getAsJsonArray();
-                    if (content != null) {
+                if (result != null) {
+                    try {
+                        JsonArray content = result.getAsJsonArray();
+                        if (content != null) {
 
-                        List<Feed> feedsJson = GSON.fromJson(content, FEED_LIST_TYPE);
+                            List<Feed> feedsJson = GSON.fromJson(content, FEED_LIST_TYPE);
 
-                        // seems to be necessary evil because of deserialization
-                        feedsJson = feedsJson.stream().peek(Feed::fixNullFields).collect(Collectors.toList());
+                            // seems to be necessary evil because of deserialization
+                            feedsJson = feedsJson.stream().peek(Feed::fixNullFields).collect(Collectors.toList());
 
-                        // replace server-provided titles with localized strings for special feeds
-                        for (Feed f : feedsJson) {
-                            try {
-                                f.title = getApplication().getString(Feed.getSpecialFeedTitleId(f.id, f.is_cat));
-                            } catch (IllegalArgumentException ignored) {
-                                // not a special feed, keep server-provided title
+                            // replace server-provided titles with localized strings for special feeds
+                            for (Feed f : feedsJson) {
+                                try {
+                                    f.title = getApplication().getString(Feed.getSpecialFeedTitleId(f.id, f.is_cat));
+                                } catch (IllegalArgumentException ignored) {
+                                    // not a special feed, keep server-provided title
+                                }
                             }
+
+                            sortFeeds(feedsJson, m_feed, new SpecialOrderComparator());
+
+                            feedsCombined.addAll(feedsJson);
                         }
+                    } catch (Exception e) {
+                        setLastError(ApiCommon.ApiError.OTHER_ERROR);
+                        setLastErrorMessage(e.getMessage());
 
-                        sortFeeds(feedsJson, m_feed, new SpecialOrderComparator());
-
-                        feedsCombined.addAll(feedsJson);
+                        e.printStackTrace();
                     }
-                } catch (Exception e) {
-                    setLastError(ApiCommon.ApiError.OTHER_ERROR);
-                    setLastErrorMessage(e.getMessage());
-
-                    e.printStackTrace();
                 }
             }
 
@@ -101,55 +103,57 @@ public class RootCategoriesModel extends FeedsModel {
 
             boolean unreadOnly = m_prefs.getBoolean("show_unread_only", true);
 
-            try {
-                JsonArray content = result.getAsJsonArray();
-                if (content != null) {
+            if (result != null) {
+                try {
+                    JsonArray content = result.getAsJsonArray();
+                    if (content != null) {
 
-                    List<Feed> feedsJson = GSON.fromJson(content, FEED_LIST_TYPE);
+                        List<Feed> feedsJson = GSON.fromJson(content, FEED_LIST_TYPE);
 
-                    // seems to be necessary evil because of deserialization
-                    feedsJson = feedsJson.stream().peek(Feed::fixNullFields).collect(Collectors.toList());
+                        // seems to be necessary evil because of deserialization
+                        feedsJson = feedsJson.stream().peek(Feed::fixNullFields).collect(Collectors.toList());
 
-                    sortFeeds(feedsJson, m_feed, new CatOrderComparator());
+                        sortFeeds(feedsJson, m_feed, new CatOrderComparator());
 
-                    // virtual cats implemented in getCategories since api level 1
-                    if (org.fox.ttrss.Application.getInstance().getApiLevel() == 0) {
-                        feedsCombined.add(0, new Feed(-2, getApplication().getString(R.string.cat_labels), true));
+                        // virtual cats implemented in getCategories since api level 1
+                        if (org.fox.ttrss.Application.getInstance().getApiLevel() == 0) {
+                            feedsCombined.add(0, new Feed(-2, getApplication().getString(R.string.cat_labels), true));
 
-                        if (!expandSpecial)
-                            feedsCombined.add(1, new Feed(-1, getApplication().getString(R.string.cat_special), true));
+                            if (!expandSpecial)
+                                feedsCombined.add(1, new Feed(-1, getApplication().getString(R.string.cat_special), true));
 
-                        feedsCombined.add(new Feed(0, getApplication().getString(R.string.cat_uncategorized), true));
-                    }
+                            feedsCombined.add(new Feed(0, getApplication().getString(R.string.cat_uncategorized), true));
+                        }
 
-                    if (unreadOnly)
+                        if (unreadOnly)
+                            feedsJson = feedsJson.stream()
+                                    .filter(f -> f.id == Feed.CAT_SPECIAL || f.unread > 0)
+                                    .collect(Collectors.toList());
+
+                        // force returned objects to become categories
                         feedsJson = feedsJson.stream()
-                                .filter(f -> f.id == Feed.CAT_SPECIAL || f.unread > 0)
+                                .peek(f -> f.is_cat = true)
                                 .collect(Collectors.toList());
 
-                    // force returned objects to become categories
-                    feedsJson = feedsJson.stream()
-                            .peek(f -> f.is_cat = true)
-                            .collect(Collectors.toList());
+                        if (expandSpecial) {
+                            feedsJson = feedsJson.stream()
+                                    .filter(f -> f.id != Feed.CAT_SPECIAL)
+                                    .collect(Collectors.toList());
 
-                    if (expandSpecial) {
-                        feedsJson = feedsJson.stream()
-                                .filter(f -> f.id != Feed.CAT_SPECIAL)
-                                .collect(Collectors.toList());
+                            if (!feedsJson.isEmpty())
+                                feedsCombined.add(new Feed(Feed.TYPE_DIVIDER));
+                        }
 
-                        if (!feedsJson.isEmpty())
-                            feedsCombined.add(new Feed(Feed.TYPE_DIVIDER));
+                        feedsCombined.addAll(feedsJson);
+
+                        m_feeds.postValue(feedsCombined);
                     }
+                } catch (Exception e) {
+                    setLastError(ApiCommon.ApiError.OTHER_ERROR);
+                    setLastErrorMessage(e.getMessage());
 
-                    feedsCombined.addAll(feedsJson);
-
-                    m_feeds.postValue(feedsCombined);
+                    e.printStackTrace();
                 }
-            } catch (Exception e) {
-                setLastError(ApiCommon.ApiError.OTHER_ERROR);
-                setLastErrorMessage(e.getMessage());
-
-                e.printStackTrace();
             }
 
             m_isLoading.postValue(false);

--- a/org.fox.ttrss/src/main/java/org/fox/ttrss/share/SubscribeActivity.java
+++ b/org.fox.ttrss/src/main/java/org/fox/ttrss/share/SubscribeActivity.java
@@ -255,7 +255,7 @@ public class SubscribeActivity extends CommonShareActivity {
 
                 if (m_lastError != null && m_lastError != ApiCommon.ApiError.SUCCESS) {
                     toast(getErrorMessage());
-                } else {
+                } else if (result != null) {
                     JsonArray content = result.getAsJsonArray();
 
                     if (content != null) {


### PR DESCRIPTION
- Fix lazy load pagination stalls in adaptive-mode and Fresh feeds when mark-as-read-on-scroll is enabled — shrinking unread counts were being mistaken for exhausted feeds.
- Guard against crashes when the API returns a null response in feed/subscribe screens.